### PR TITLE
feat(agent): add rule-based fast path and category cache

### DIFF
--- a/apps/api/src/agent/agent.constants.ts
+++ b/apps/api/src/agent/agent.constants.ts
@@ -1,0 +1,7 @@
+export type AgentLanguage = 'vi' | 'en';
+
+export const DEFAULT_LANGUAGE: AgentLanguage = 'vi';
+export const DEFAULT_TIMEZONE = 'Asia/Ho_Chi_Minh';
+export const DEFAULT_RECENT_COUNT = 5;
+
+export const SYSTEM_PROMPT_TEMPLATE = `You are an expense intent parser. CURRENT_TIME={{NOW_ISO}} TIMEZONE={{TIMEZONE}}. Return one JSON object with keys:{"intent":"add_expense|add_income|query_total|query_by_category|set_budget|get_budget_status|list_recent|undo_or_delete|small_talk","language":"vi|en","amount":number?,"currency":"VND|USD"?,"category":string?,"note":string?,"occurred_at":string?,"period":"today|yesterday|this_week|this_month|last_month|this_year"?,"date_from":string?,"date_to":string?,"budget_month":number?,"budget_year":number?,"confidence":number?}Rules: JSON only, no code fences or prose. Detect language; default vi when Vietnamese markers (k,tr,nghin,trieu). Interpret shorthand (k,tr,nghin,trieu) as numeric VND; currency defaults VND if unclear. Use CURRENT_TIME/TIMEZONE for relative dates. Map categories to: An uong, Di chuyen, Nha o, Mua sam, Giai tri, Suc khoe, Giao duc, Hoa don, Thu nhap, Khac. Pick intent per definitions; use small_talk for casual chat.`;

--- a/apps/api/src/agent/agent.service.ts
+++ b/apps/api/src/agent/agent.service.ts
@@ -1,13 +1,6 @@
 ﻿import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import {
-  AgentPayload,
-  AgentPayloadSchema,
-  Intent,
-  TimePeriodEnum,
-  normalizeText,
-  resolveCategoryName,
-} from '@expense-ai/shared';
+import { AgentPayload, Intent, normalizeText, resolveCategoryName } from '@expense-ai/shared';
 import { HyperbolicService, HyperbolicMessage } from '../integrations/hyperbolic.service';
 import { TransactionsService } from '../transactions/transactions.service';
 import { BudgetsService } from '../budgets/budgets.service';
@@ -19,21 +12,49 @@ import { AgentChatResult } from './types/agent-response.type';
 import { ChatMessageStatus, ChatRole, Currency, Prisma, TxnType } from '@prisma/client';
 import { DateTime } from 'luxon';
 
-const DEFAULT_TIMEZONE = 'Asia/Ho_Chi_Minh';
-const DEFAULT_RECENT_COUNT = 5;
-
-type AgentLanguage = 'vi' | 'en';
-const DEFAULT_LANGUAGE: AgentLanguage = 'vi';
-
-type TransactionResult = Awaited<ReturnType<TransactionsService['create']>>;
-type BudgetStatusResult = Awaited<ReturnType<BudgetsService['status']>>;
+import {
+  AgentLanguage,
+  DEFAULT_LANGUAGE,
+  DEFAULT_RECENT_COUNT,
+  DEFAULT_TIMEZONE,
+} from './agent.constants';
+import {
+  buildAskBudgetAmountReply,
+  buildBudgetExceededWarning,
+  buildBudgetNotFoundReply,
+  buildBudgetSetReply,
+  buildBudgetStatusReply,
+  buildClassificationErrorReply,
+  buildEmptyMessageReply,
+  buildHandlerErrorReply,
+  buildLowConfidenceReply,
+  buildMissingAmountReply,
+  buildNoTransactionsReply,
+  buildRecentTransactionLine,
+  buildRecentTransactionsHeader,
+  buildSmallTalkReply,
+  buildSummaryByCategoryReply,
+  buildSummaryTotalsReply,
+  buildTransactionSavedReply,
+  buildUndoNotSupportedReply,
+  buildUnsupportedIntentReply,
+  describeRange,
+  formatCurrency,
+  formatDate,
+  formatMonthYear,
+  getBudgetTargetLabel,
+  getCategoryLabel,
+  getOtherCategoryLabel,
+} from './utils/agent-response.utils';
+import { buildClassificationPrompt } from './utils/classification.util';
+import { logRawCompletion, parseAgentPayload } from './utils/payload.util';
+import { classifyRuleBased } from './utils/rule-based.util';
+import type { TransactionResult } from './types/internal.types';
 
 @Injectable()
 export class AgentService {
   private readonly logger = new Logger(AgentService.name);
-  private readonly systemPromptTemplate = `You are an expense intent parser. CURRENT_TIME={{NOW_ISO}} TIMEZONE={{TIMEZONE}}. Return one JSON object with keys:
-{"intent":"add_expense|add_income|query_total|query_by_category|set_budget|get_budget_status|list_recent|undo_or_delete|small_talk","language":"vi|en","amount":number?,"currency":"VND|USD"?,"category":string?,"note":string?,"occurred_at":string?,"period":"today|yesterday|this_week|this_month|last_month|this_year"?,"date_from":string?,"date_to":string?,"budget_month":number?,"budget_year":number?,"confidence":number?}
-Rules: JSON only, no code fences or prose. Detect language; default vi when Vietnamese markers (k,tr,nghin,trieu). Interpret shorthand (k,tr,nghin,trieu) as numeric VND; currency defaults VND if unclear. Use CURRENT_TIME/TIMEZONE for relative dates. Map categories to: An uong, Di chuyen, Nha o, Mua sam, Giai tri, Suc khoe, Giao duc, Hoa don, Thu nhap, Khac. Pick intent per definitions; use small_talk for casual chat.`
+  private readonly categoryCache = new Map<string, string | null>();
 
 
   constructor(
@@ -50,49 +71,54 @@ Rules: JSON only, no code fences or prose. Detect language; default vi when Viet
 
     if (!trimmed) {
       return {
-        reply: this.buildEmptyMessageReply(fallbackLanguage),
+        reply: buildEmptyMessageReply(fallbackLanguage),
         intent: 'clarify',
       };
     }
 
     await this.persistUserMessage(user.id, trimmed);
 
+    let payload: AgentPayload | undefined;
     const timezone = this.configService.get<string>('APP_TIMEZONE') ?? DEFAULT_TIMEZONE;
     const now = new Date();
-    const systemPrompt = this.buildClassificationPrompt(now, timezone);
 
-    const chatMessages: HyperbolicMessage[] = [
-      { role: 'system', content: systemPrompt },
-      { role: 'user', content: trimmed },
-    ];
+    payload = classifyRuleBased(trimmed, { now, timezone, language: fallbackLanguage }) ?? undefined;
 
-    let payload: AgentPayload | undefined;
+    if (!payload) {
+      const systemPrompt = buildClassificationPrompt(now, timezone);
+      const chatMessages: HyperbolicMessage[] = [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: trimmed },
+      ];
 
-    try {
-      const raw = await this.hyperbolicService.complete(chatMessages, {
-        max_tokens: 350,
-        temperature: 0.1,
-        top_p: 0.8,
-        response_format: { type: 'json_object' },
-      });
+      try {
+        const raw = await this.hyperbolicService.complete(chatMessages, {
+          max_tokens: 350,
+          temperature: 0.1,
+          top_p: 0.8,
+          response_format: { type: 'json_object' },
+        });
 
-      this.logRawCompletion(raw);
+        logRawCompletion(this.logger, raw);
 
-      payload = this.parseAgentPayload(raw);
-    } catch (error) {
-      this.logger.error('Agent classification failed', error instanceof Error ? error.stack : error);
-      return this.finalizeResponse(user.id, {
-        reply: this.buildClassificationErrorReply(fallbackLanguage),
-        intent: 'error',
-        error: error instanceof Error ? error.message : String(error),
-      });
+        payload = parseAgentPayload(this.logger, raw);
+      } catch (error) {
+        this.logger.error('Agent classification failed', error instanceof Error ? error.stack : error);
+        return this.finalizeResponse(user.id, {
+          reply: buildClassificationErrorReply(fallbackLanguage),
+          intent: 'error',
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    } else {
+      this.logger.debug('Rule-based fast path classified message; skipped LLM call');
     }
 
     const language = this.getLanguageFromPayload(payload);
 
     if (payload.confidence !== undefined && payload.confidence < 0.6) {
       return this.finalizeResponse(user.id, {
-        reply: this.buildLowConfidenceReply(language),
+        reply: buildLowConfidenceReply(language),
         intent: 'clarify',
         parsed: payload,
       });
@@ -121,7 +147,7 @@ Rules: JSON only, no code fences or prose. Detect language; default vi when Viet
           break;
         case 'undo_or_delete':
           result = {
-            reply: this.buildUndoNotSupportedReply(language),
+            reply: buildUndoNotSupportedReply(language),
             intent: 'clarify',
             parsed: payload,
           };
@@ -131,7 +157,7 @@ Rules: JSON only, no code fences or prose. Detect language; default vi when Viet
           break;
         default:
           result = {
-            reply: this.buildUnsupportedIntentReply(language),
+            reply: buildUnsupportedIntentReply(language),
             intent: 'error',
             parsed: payload,
           };
@@ -142,7 +168,7 @@ Rules: JSON only, no code fences or prose. Detect language; default vi when Viet
     } catch (error) {
       this.logger.error('Agent handler failed', error instanceof Error ? error.stack : error);
       return this.finalizeResponse(user.id, {
-        reply: this.buildHandlerErrorReply(language),
+        reply: buildHandlerErrorReply(language),
         intent: 'error',
         parsed: payload,
         error: error instanceof Error ? error.message : String(error),
@@ -199,12 +225,6 @@ Rules: JSON only, no code fences or prose. Detect language; default vi when Viet
     return result;
   }
 
-  private buildClassificationPrompt(now: Date, timezone: string): string {
-    return this.systemPromptTemplate
-      .replace('{{NOW_ISO}}', now.toISOString())
-      .replace('{{TIMEZONE}}', timezone);
-  }
-
   private async handleAddTransaction(
     user: PublicUser,
     originalMessage: string,
@@ -213,7 +233,7 @@ Rules: JSON only, no code fences or prose. Detect language; default vi when Viet
   ): Promise<AgentChatResult> {
     if (!payload.amount || payload.amount <= 0) {
       return {
-        reply: this.buildMissingAmountReply(language),
+        reply: buildMissingAmountReply(language),
         intent: 'clarify',
         parsed: payload,
       };
@@ -242,10 +262,10 @@ Rules: JSON only, no code fences or prose. Detect language; default vi when Viet
 
     const transaction = await this.transactionsService.create(user.id, dto);
 
-    const amountLabel = this.formatCurrency(transaction.amount, transaction.currency, language);
+    const amountLabel = formatCurrency(transaction.amount, transaction.currency, language);
     const categoryLabel = transaction.category?.name ?? categoryName ?? null;
 
-    let reply = this.buildTransactionSavedReply(language, {
+    let reply = buildTransactionSavedReply(language, {
       type,
       amount: amountLabel,
       category: categoryLabel,
@@ -274,7 +294,7 @@ Rules: JSON only, no code fences or prose. Detect language; default vi when Viet
   ): Promise<AgentChatResult> {
     if (!payload.amount || payload.amount <= 0) {
       return {
-        reply: this.buildAskBudgetAmountReply(language),
+        reply: buildAskBudgetAmountReply(language),
         intent: 'clarify',
         parsed: payload,
       };
@@ -296,12 +316,12 @@ Rules: JSON only, no code fences or prose. Detect language; default vi when Viet
       categoryId: category?.id,
     });
 
-    const amountLabel = this.formatCurrency(budget.limitAmount, budget.currency, language);
-    const monthLabel = this.formatMonthYear(month, year, language);
-    const categoryLabel = this.getCategoryLabel(language, category?.name ?? categoryName ?? null);
+    const amountLabel = formatCurrency(budget.limitAmount, budget.currency, language);
+    const monthLabel = formatMonthYear(month, year, language);
+    const categoryLabel = getCategoryLabel(language, category?.name ?? categoryName ?? null);
 
     return {
-      reply: this.buildBudgetSetReply(language, {
+      reply: buildBudgetSetReply(language, {
         amountLabel,
         categoryLabel,
         monthLabel,
@@ -336,28 +356,28 @@ Rules: JSON only, no code fences or prose. Detect language; default vi when Viet
     });
 
     if (!budget) {
-      const monthLabel = this.formatMonthYear(month, year, language);
-      const target = this.getBudgetTargetLabel(language, category?.name ?? categoryName ?? null);
+      const monthLabel = formatMonthYear(month, year, language);
+      const target = getBudgetTargetLabel(language, category?.name ?? categoryName ?? null);
       return {
-        reply: this.buildBudgetNotFoundReply(language, { target, monthLabel }),
+        reply: buildBudgetNotFoundReply(language, { target, monthLabel }),
         intent: 'clarify',
         parsed: payload,
       };
     }
 
     const status = await this.budgetsService.status(user.id, budget.id);
-    const amountLabel = this.formatCurrency(status.spent, status.budget.currency, language);
-    const limitLabel = this.formatCurrency(status.budget.limitAmount, status.budget.currency, language);
+    const amountLabel = formatCurrency(status.spent, status.budget.currency, language);
+    const limitLabel = formatCurrency(status.budget.limitAmount, status.budget.currency, language);
     const percentLabel = `${status.percentage}%`;
-    const remainingLabel = this.formatCurrency(status.remaining, status.budget.currency, language);
+    const remainingLabel = formatCurrency(status.remaining, status.budget.currency, language);
     const overspentLabel =
       status.overBudget && status.overspent > 0
-        ? this.formatCurrency(status.overspent, status.budget.currency, language)
+        ? formatCurrency(status.overspent, status.budget.currency, language)
         : undefined;
-    const endDateLabel = status.range?.end ? this.formatDate(status.range.end, timezone) : undefined;
+    const endDateLabel = status.range?.end ? formatDate(status.range.end, timezone) : undefined;
 
     return {
-      reply: this.buildBudgetStatusReply(language, {
+      reply: buildBudgetStatusReply(language, {
         amountLabel,
         limitLabel,
         percentLabel,
@@ -405,20 +425,7 @@ Rules: JSON only, no code fences or prose. Detect language; default vi when Viet
 
     return statuses
       .filter((status) => status.overBudget)
-      .map((status) => this.buildBudgetExceededWarning(language, status));
-  }
-
-  private buildBudgetExceededWarning(
-    language: AgentLanguage,
-    status: BudgetStatusResult,
-  ): string {
-    const target = this.getBudgetTargetLabel(language, status.budget.category?.name ?? null);
-    const monthLabel = this.formatMonthYear(status.budget.month, status.budget.year, language);
-    const overspentLabel = this.formatCurrency(status.overspent, status.budget.currency, language);
-
-    return language === 'vi'
-      ? `Bạn đã vượt ${target} ${overspentLabel} trong ${monthLabel}.`
-      : `You've exceeded ${target} by ${overspentLabel} in ${monthLabel}.`;
+      .map((status) => buildBudgetExceededWarning(language, status));
   }
 
   private async handleSummary(
@@ -444,7 +451,7 @@ Rules: JSON only, no code fences or prose. Detect language; default vi when Viet
 
     const summary = await this.transactionsService.summary(user.id, summaryInput);
 
-    const rangeLabel = this.describeRange(
+    const rangeLabel = describeRange(
       summary.range?.start,
       summary.range?.end,
       timezone,
@@ -454,8 +461,8 @@ Rules: JSON only, no code fences or prose. Detect language; default vi when Viet
 
     if (payload.intent === 'query_by_category' && category) {
       const byCategory = summary.byCategory.find((item) => item.categoryId === category.id);
-      const amountLabel = this.formatCurrency(byCategory?.amount ?? 0, currency, language);
-      const reply = this.buildSummaryByCategoryReply(language, {
+      const amountLabel = formatCurrency(byCategory?.amount ?? 0, currency, language);
+      const reply = buildSummaryByCategoryReply(language, {
         rangeLabel,
         amountLabel,
         categoryName: category.name,
@@ -469,10 +476,10 @@ Rules: JSON only, no code fences or prose. Detect language; default vi when Viet
       };
     }
 
-    const expenseLabel = this.formatCurrency(summary.totals.expense, currency, language);
-    const incomeLabel = this.formatCurrency(summary.totals.income, currency, language);
-    const netLabel = this.formatCurrency(summary.totals.net, currency, language);
-    const reply = this.buildSummaryTotalsReply(language, {
+    const expenseLabel = formatCurrency(summary.totals.expense, currency, language);
+    const incomeLabel = formatCurrency(summary.totals.income, currency, language);
+    const netLabel = formatCurrency(summary.totals.net, currency, language);
+    const reply = buildSummaryTotalsReply(language, {
       rangeLabel,
       expenseLabel,
       incomeLabel,
@@ -515,7 +522,7 @@ Rules: JSON only, no code fences or prose. Detect language; default vi when Viet
 
     if (!result.data.length) {
       return {
-        reply: this.buildNoTransactionsReply(language),
+        reply: buildNoTransactionsReply(language),
         intent: payload.intent,
         parsed: payload,
         data: { transactions: result },
@@ -523,13 +530,13 @@ Rules: JSON only, no code fences or prose. Detect language; default vi when Viet
     }
 
     const lines = result.data.map((item) => {
-      const amount = this.formatCurrency(item.amount, item.currency, language);
-      const date = this.formatDate(item.occurredAt, timezone);
-      const label = item.category?.name ?? this.getOtherCategoryLabel(language);
-      return this.buildRecentTransactionLine({ date, amount, category: label });
+      const amount = formatCurrency(item.amount, item.currency, language);
+      const date = formatDate(item.occurredAt, timezone);
+      const label = item.category?.name ?? getOtherCategoryLabel(language);
+      return buildRecentTransactionLine({ date, amount, category: label });
     });
 
-    const reply = `${this.buildRecentTransactionsHeader(language)}\n${lines.join('\n')}`;
+    const reply = `${buildRecentTransactionsHeader(language)}\n${lines.join('\n')}`;
 
     return {
       reply,
@@ -546,14 +553,25 @@ Rules: JSON only, no code fences or prose. Detect language; default vi when Viet
   ): AgentChatResult {
     const name = user.name ?? user.email;
     return {
-      reply: this.buildSmallTalkReply(language, name),
+      reply: buildSmallTalkReply(language, name),
       intent: payload.intent,
       parsed: payload,
     };
   }
 
   private resolveCategory(input: string): string | null {
-    return resolveCategoryName(input);
+    const normalized = normalizeText(input);
+    if (!normalized) {
+      return null;
+    }
+
+    if (this.categoryCache.has(normalized)) {
+      return this.categoryCache.get(normalized) ?? null;
+    }
+
+    const resolved = resolveCategoryName(input);
+    this.categoryCache.set(normalized, resolved);
+    return resolved;
   }
 
   private async findCategoryByName(name: string) {
@@ -565,121 +583,6 @@ Rules: JSON only, no code fences or prose. Detect language; default vi when Viet
         },
       },
     });
-  }
-
-  private logRawCompletion(raw: string): void {
-    const cleaned = raw.replace(/\s+/g, ' ').trim();
-    const preview = cleaned.length > 1000 ? `${cleaned.slice(0, 1000)}...` : cleaned;
-    this.logger.debug(`Hyperbolic raw response preview: ${preview}`);
-  }
-  private parseAgentPayload(raw: string): AgentPayload {
-    const jsonString = this.extractJsonString(raw);
-
-    try {
-      const parsed = JSON.parse(jsonString);
-      return AgentPayloadSchema.parse(this.normalizeAgentPayload(parsed));
-    } catch (error) {
-      const fallback = this.findJsonObject(raw);
-      if (fallback) {
-        try {
-          const parsedFallback = JSON.parse(fallback);
-          return AgentPayloadSchema.parse(this.normalizeAgentPayload(parsedFallback));
-        } catch (innerError) {
-          this.logger.warn('Failed to parse JSON snippet from LLM response', innerError);
-        }
-      }
-      throw error;
-    }
-  }
-
-  private extractJsonString(raw: string): string {
-    const withoutThinking = raw.replace(/<think>[\s\S]*?<\/think>/g, '').trim();
-    const channelRegex = /<\|channel\|>([a-zA-Z0-9_]+)<\|message\|>([\s\S]*?)(?=(<\|channel\|>[a-zA-Z0-9_]+<\|message\|>)|$)/g;
-
-    let finalContent: string | undefined;
-    let fallbackContent: string | undefined;
-
-    for (const match of withoutThinking.matchAll(channelRegex)) {
-      const channel = match[1];
-      const content = match[2].trim();
-
-      if (channel === 'final') {
-        finalContent = content;
-        break;
-      }
-
-      if (!fallbackContent) {
-        const candidate = this.findJsonObject(content);
-        if (candidate) {
-          fallbackContent = candidate;
-        }
-      }
-    }
-
-    const target = finalContent ?? fallbackContent ?? withoutThinking;
-    const json = this.findJsonObject(target);
-
-    if (!json) {
-      throw new Error('No JSON object found in LLM response');
-    }
-
-    return json;
-  }
-
-  private findJsonObject(text: string): string | undefined {
-    const match = text.match(/\{[\s\S]*\}/);
-    return match ? match[0] : undefined;
-  }
-
-  private normalizeAgentPayload(payload: unknown): unknown {
-    if (!payload || typeof payload !== 'object') {
-      return payload;
-    }
-
-    const clone: Record<string, unknown> = { ...(payload as Record<string, unknown>) };
-    const occurredAt = clone.occurred_at;
-
-    if (typeof occurredAt === 'string' && occurredAt.trim().length > 0) {
-      const parsed = DateTime.fromISO(occurredAt, { setZone: true });
-      if (parsed.isValid) {
-        clone.occurred_at = parsed.toUTC().toISO();
-      } else {
-        const parsedUTC = DateTime.fromISO(occurredAt);
-        if (parsedUTC.isValid) {
-          clone.occurred_at = parsedUTC.toUTC().toISO();
-        }
-      }
-    }
-
-    const rawBudgetMonth = clone.budget_month;
-    if (typeof rawBudgetMonth === 'string' && rawBudgetMonth.trim().length > 0) {
-      const numericMonth = Number(rawBudgetMonth);
-      clone.budget_month = Number.isFinite(numericMonth) ? numericMonth : rawBudgetMonth;
-    }
-
-    if (typeof clone.budget_month === 'number') {
-      if (clone.budget_month < 1 || clone.budget_month > 12) {
-        delete clone.budget_month;
-      } else {
-        clone.budget_month = Math.trunc(clone.budget_month);
-      }
-    }
-
-    const rawBudgetYear = clone.budget_year;
-    if (typeof rawBudgetYear === 'string' && rawBudgetYear.trim().length > 0) {
-      const numericYear = Number(rawBudgetYear);
-      clone.budget_year = Number.isFinite(numericYear) ? numericYear : rawBudgetYear;
-    }
-
-    if (typeof clone.budget_year === 'number') {
-      if (clone.budget_year < 1900 || clone.budget_year > 3000) {
-        delete clone.budget_year;
-      } else {
-        clone.budget_year = Math.trunc(clone.budget_year);
-      }
-    }
-
-    return clone;
   }
 
   private detectSummaryType(intent: Intent, categoryName: string | null): TxnType | undefined {
@@ -696,78 +599,6 @@ Rules: JSON only, no code fences or prose. Detect language; default vi when Viet
     }
 
     return undefined;
-  }
-
-  private formatCurrency(amount: number, currency: Currency, language: AgentLanguage): string {
-    const locale = language === 'vi' ? 'vi-VN' : 'en-US';
-    const formatter = new Intl.NumberFormat(locale, {
-      style: 'currency',
-      currency,
-      minimumFractionDigits: currency === Currency.VND ? 0 : 2,
-      maximumFractionDigits: currency === Currency.VND ? 0 : 2,
-    });
-    return formatter.format(amount);
-  }
-
-  private formatDate(value: string, timezone: string): string {
-    const dt = DateTime.fromISO(value, { zone: timezone });
-    if (!dt.isValid) {
-      return value;
-    }
-    return dt.toFormat('dd/MM/yyyy');
-  }
-
-  private formatMonthYear(month: number, year: number, language: AgentLanguage): string {
-    return language === 'vi' ? `tháng ${month}/${year}` : `${month}/${year}`;
-  }
-
-  private describeRange(
-    startIso: string | undefined,
-    endIso: string | undefined,
-    timezone: string,
-    language: AgentLanguage,
-    period?: TimePeriodEnum,
-  ): string {
-    if (!startIso && !endIso && !period) {
-      return language === 'vi' ? 'Trong khoảng thời gian bạn chọn' : 'In the selected period';
-    }
-
-    if (startIso && endIso) {
-      const start = this.formatDate(startIso, timezone);
-      const end = this.formatDate(endIso, timezone);
-      return language === 'vi' ? `Từ ${start} đến ${end}` : `From ${start} to ${end}`;
-    }
-
-    if (period) {
-      switch (period) {
-        case TimePeriodEnum.Today:
-          return language === 'vi' ? 'Hôm nay' : 'Today';
-        case TimePeriodEnum.Yesterday:
-          return language === 'vi' ? 'Hôm qua' : 'Yesterday';
-        case TimePeriodEnum.ThisWeek:
-          return language === 'vi' ? 'Tuần này' : 'This week';
-        case TimePeriodEnum.ThisMonth:
-          return language === 'vi' ? 'Tháng này' : 'This month';
-        case TimePeriodEnum.LastMonth:
-          return language === 'vi' ? 'Tháng trước' : 'Last month';
-        case TimePeriodEnum.ThisYear:
-          return language === 'vi' ? 'Năm nay' : 'This year';
-        default:
-          break;
-      }
-    }
-
-    if (startIso) {
-      const formatted = this.formatDate(startIso, timezone);
-      return language === 'vi' ? `Từ ${formatted}` : `From ${formatted}`;
-    }
-
-    if (endIso) {
-      const formatted = this.formatDate(endIso, timezone);
-      return language === 'vi' ? `Đến ${formatted}` : `Until ${formatted}`;
-    }
-
-    return language === 'vi' ? 'Trong khoảng thời gian bạn chọn' : 'In the selected period';
   }
 
   private getLanguageFromPayload(payload?: AgentPayload): AgentLanguage {
@@ -819,201 +650,5 @@ Rules: JSON only, no code fences or prose. Detect language; default vi when Viet
     );
   }
 
-  private buildEmptyMessageReply(language: AgentLanguage): string {
-    return language === 'vi'
-      ? 'Bạn hãy nói rõ hơn điều muốn làm để mình hỗ trợ nhé.'
-      : 'Please tell me more clearly what you\'d like help with.';
-  }
-
-  private buildClassificationErrorReply(language: AgentLanguage): string {
-    return language === 'vi'
-      ? 'Xin lỗi, mình gặp trục trặc khi phân tích tin nhắn. Bạn thử nói lại giúp mình nhé.'
-      : 'Sorry, I ran into an issue while parsing that message. Could you try again?';
-  }
-
-  private buildLowConfidenceReply(language: AgentLanguage): string {
-    return language === 'vi'
-      ? 'Mình chưa chắc chắn là hiểu đúng nội dung. Bạn có thể nói rõ hơn hoặc bổ sung thông tin nhé?'
-      : 'I\'m not fully sure I understood. Could you clarify or add a bit more detail?';
-  }
-
-  private buildUndoNotSupportedReply(language: AgentLanguage): string {
-    return language === 'vi'
-      ? 'Mình đang xây dựng tính năng hủy giao dịch. Bạn có thể xóa thủ công trong danh sách giao dịch nhé.'
-      : 'I\'m still building the undo feature. You can delete the transaction manually in the list for now.';
-  }
-
-  private buildUnsupportedIntentReply(language: AgentLanguage): string {
-    return language === 'vi'
-      ? 'Tính năng này chưa được hỗ trợ. Bạn thử yêu cầu khác giúp mình nhé.'
-      : 'That capability isn\'t supported yet. Please try a different request.';
-  }
-
-  private buildHandlerErrorReply(language: AgentLanguage): string {
-    return language === 'vi'
-      ? 'Xin lỗi, mình gặp lỗi khi xử lý. Bạn thử lại sau ít phút giúp mình nhé.'
-      : 'Sorry, something went wrong while handling that. Please try again shortly.';
-  }
-
-  private buildMissingAmountReply(language: AgentLanguage): string {
-    return language === 'vi'
-      ? 'Mình chưa thấy số tiền. Bạn cho mình biết cụ thể hoặc nhập lại giúp nhé.'
-      : 'I didn\'t catch the amount. Could you tell me the number or rephrase?';
-  }
-
-  private buildTransactionSavedReply(
-    language: AgentLanguage,
-    params: { type: TxnType; amount: string; category?: string | null },
-  ): string {
-    const { type, amount, category } = params;
-    const categoryClause = category
-      ? language === 'vi'
-        ? ` cho ${category}`
-        : ` for ${category}`
-      : '';
-    if (language === 'vi') {
-      const noun = type === TxnType.INCOME ? 'khoản thu' : 'khoản chi';
-      return `Mình đã ghi nhận ${noun} ${amount}${categoryClause}.`;
-    }
-    const base =
-      type === TxnType.INCOME
-        ? `I've recorded income of ${amount}`
-        : `I've recorded an expense of ${amount}`;
-    return `${base}${categoryClause}.`;
-  }
-
-  private buildAskBudgetAmountReply(language: AgentLanguage): string {
-    return language === 'vi'
-      ? 'Bạn muốn đặt ngân sách bao nhiêu? Mình cần số tiền cụ thể nhé.'
-      : 'How much budget would you like to set? I need the exact amount.';
-  }
-
-  private buildBudgetSetReply(
-    language: AgentLanguage,
-    params: { amountLabel: string; categoryLabel: string; monthLabel: string },
-  ): string {
-    const { amountLabel, categoryLabel, monthLabel } = params;
-    return language === 'vi'
-      ? `Mình đã cập nhật ngân sách ${amountLabel} cho ${categoryLabel} (${monthLabel}).`
-      : `I've updated the budget to ${amountLabel} for ${categoryLabel} (${monthLabel}).`;
-  }
-
-  private buildBudgetNotFoundReply(
-    language: AgentLanguage,
-    params: { target: string; monthLabel: string },
-  ): string {
-    const { target, monthLabel } = params;
-    return language === 'vi'
-      ? `Mình chưa thấy ${target} trong ${monthLabel}. Bạn có thể đặt ngân sách trước nhé.`
-      : `I couldn't find ${target} in ${monthLabel}. Try setting the budget first.`;
-  }
-
-  private buildBudgetStatusReply(
-    language: AgentLanguage,
-    params: {
-      amountLabel: string;
-      limitLabel: string;
-      percentLabel: string;
-      remainingLabel: string;
-      endDateLabel?: string;
-      overBudget: boolean;
-      overspentLabel?: string;
-    },
-  ): string {
-    const {
-      amountLabel,
-      limitLabel,
-      percentLabel,
-      remainingLabel,
-      endDateLabel,
-      overBudget,
-      overspentLabel,
-    } = params;
-    const trailing = endDateLabel
-      ? language === 'vi'
-        ? ` Ngân sách kết thúc vào ${endDateLabel}.`
-        : ` The budget ends on ${endDateLabel}.`
-      : '';
-
-    if (overBudget && overspentLabel) {
-      const warning = language === 'vi'
-        ? ` Cảnh báo: bạn đã vượt ngân sách ${overspentLabel}.`
-        : ` Warning: you're over budget by ${overspentLabel}.`;
-      return language === 'vi'
-        ? `Bạn đang dùng ${amountLabel} / ${limitLabel} (${percentLabel}).${warning}${trailing}`
-        : `You've spent ${amountLabel} / ${limitLabel} (${percentLabel}).${warning}${trailing}`;
-    }
-
-    const remainingSentence = language === 'vi'
-      ? ` Còn lại ${remainingLabel}.`
-      : ` Remaining ${remainingLabel}.`;
-
-    return language === 'vi'
-      ? `Bạn đang dùng ${amountLabel} / ${limitLabel} (${percentLabel}).${remainingSentence}${trailing}`
-      : `You've spent ${amountLabel} / ${limitLabel} (${percentLabel}).${remainingSentence}${trailing}`;
-  }
-
-  private buildSummaryByCategoryReply(
-    language: AgentLanguage,
-    params: { rangeLabel: string; amountLabel: string; categoryName: string },
-  ): string {
-    const { rangeLabel, amountLabel, categoryName } = params;
-    return language === 'vi'
-      ? `${rangeLabel} bạn đã chi ${amountLabel} cho ${categoryName}.`
-      : `${rangeLabel}, you spent ${amountLabel} on ${categoryName}.`;
-  }
-
-  private buildSummaryTotalsReply(
-    language: AgentLanguage,
-    params: { rangeLabel: string; expenseLabel: string; incomeLabel: string; netLabel: string },
-  ): string {
-    const { rangeLabel, expenseLabel, incomeLabel, netLabel } = params;
-    return language === 'vi'
-      ? `${rangeLabel} bạn đã chi ${expenseLabel} và thu ${incomeLabel} (chênh lệch ${netLabel}).`
-      : `${rangeLabel}, you spent ${expenseLabel} and earned ${incomeLabel} (net ${netLabel}).`;
-  }
-
-  private buildNoTransactionsReply(language: AgentLanguage): string {
-    return language === 'vi'
-      ? 'Chưa có giao dịch nào trong khoảng thời gian đó.'
-      : 'No transactions found for that timeframe.';
-  }
-
-  private buildRecentTransactionsHeader(language: AgentLanguage): string {
-    return language === 'vi' ? 'Các giao dịch gần đây:' : 'Recent transactions:';
-  }
-
-  private buildRecentTransactionLine(params: {
-    date: string;
-    amount: string;
-    category: string;
-  }): string {
-    const { date, amount, category } = params;
-    return `- ${date}: ${amount} (${category})`;
-  }
-
-  private buildSmallTalkReply(language: AgentLanguage, name: string): string {
-    return language === 'vi'
-      ? `Chào ${name}! Mình ở đây để giúp bạn quản lý chi tiêu, cứ hỏi nhé.`
-      : `Hi ${name}! I'm here to help you manage your spending, just let me know what you need.`;
-  }
-
-  private getCategoryLabel(language: AgentLanguage, categoryName?: string | null): string {
-    if (categoryName) {
-      return categoryName;
-    }
-    return language === 'vi' ? 'tất cả danh mục' : 'all categories';
-  }
-
-  private getBudgetTargetLabel(language: AgentLanguage, categoryName?: string | null): string {
-    if (categoryName) {
-      return language === 'vi' ? `ngân sách cho ${categoryName}` : `the ${categoryName} budget`;
-    }
-    return language === 'vi' ? 'ngân sách này' : 'this budget';
-  }
-
-  private getOtherCategoryLabel(language: AgentLanguage): string {
-    return language === 'vi' ? 'Khác' : 'Other';
-  }
 }
 

--- a/apps/api/src/agent/types/internal.types.ts
+++ b/apps/api/src/agent/types/internal.types.ts
@@ -1,0 +1,5 @@
+import type { BudgetsService } from '../../budgets/budgets.service';
+import type { TransactionsService } from '../../transactions/transactions.service';
+
+export type TransactionResult = Awaited<ReturnType<TransactionsService['create']>>;
+export type BudgetStatusResult = Awaited<ReturnType<BudgetsService['status']>>;

--- a/apps/api/src/agent/utils/agent-response.utils.ts
+++ b/apps/api/src/agent/utils/agent-response.utils.ts
@@ -1,0 +1,288 @@
+import { DateTime } from 'luxon';
+import { Currency, TxnType } from '@prisma/client';
+import { TimePeriodEnum } from '@expense-ai/shared';
+
+import { AgentLanguage } from '../agent.constants';
+import type { BudgetStatusResult } from '../types/internal.types';
+
+export function formatCurrency(amount: number, currency: Currency, language: AgentLanguage): string {
+  const locale = language === 'vi' ? 'vi-VN' : 'en-US';
+  const formatter = new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency,
+    minimumFractionDigits: currency === Currency.VND ? 0 : 2,
+    maximumFractionDigits: currency === Currency.VND ? 0 : 2,
+  });
+  return formatter.format(amount);
+}
+
+export function formatDate(value: string, timezone: string): string {
+  const dt = DateTime.fromISO(value, { zone: timezone });
+  if (!dt.isValid) {
+    return value;
+  }
+  return dt.toFormat('dd/MM/yyyy');
+}
+
+export function formatMonthYear(month: number, year: number, language: AgentLanguage): string {
+  return language === 'vi' ? `tháng ${month}/${year}` : `${month}/${year}`;
+}
+
+export function describeRange(
+  startIso: string | undefined,
+  endIso: string | undefined,
+  timezone: string,
+  language: AgentLanguage,
+  period?: TimePeriodEnum,
+): string {
+  if (!startIso && !endIso && !period) {
+    return language === 'vi' ? 'Trong khoảng thời gian bạn chọn' : 'In the selected period';
+  }
+
+  if (startIso && endIso) {
+    const start = formatDate(startIso, timezone);
+    const end = formatDate(endIso, timezone);
+    return language === 'vi' ? `Từ ${start} đến ${end}` : `From ${start} to ${end}`;
+  }
+
+  if (period) {
+    switch (period) {
+      case TimePeriodEnum.Today:
+        return language === 'vi' ? 'Hôm nay' : 'Today';
+      case TimePeriodEnum.Yesterday:
+        return language === 'vi' ? 'Hôm qua' : 'Yesterday';
+      case TimePeriodEnum.ThisWeek:
+        return language === 'vi' ? 'Tuần này' : 'This week';
+      case TimePeriodEnum.ThisMonth:
+        return language === 'vi' ? 'Tháng này' : 'This month';
+      case TimePeriodEnum.LastMonth:
+        return language === 'vi' ? 'Tháng trước' : 'Last month';
+      case TimePeriodEnum.ThisYear:
+        return language === 'vi' ? 'Năm nay' : 'This year';
+      default:
+        break;
+    }
+  }
+
+  if (startIso) {
+    const formatted = formatDate(startIso, timezone);
+    return language === 'vi' ? `Từ ${formatted}` : `From ${formatted}`;
+  }
+
+  if (endIso) {
+    const formatted = formatDate(endIso, timezone);
+    return language === 'vi' ? `Đến ${formatted}` : `Until ${formatted}`;
+  }
+
+  return language === 'vi' ? 'Trong khoảng thời gian bạn chọn' : 'In the selected period';
+}
+
+export function buildEmptyMessageReply(language: AgentLanguage): string {
+  return language === 'vi'
+    ? 'Bạn hãy nói rõ hơn điều muốn làm để mình hỗ trợ nhé.'
+    : "Please tell me more clearly what you'd like help with.";
+}
+
+export function buildClassificationErrorReply(language: AgentLanguage): string {
+  return language === 'vi'
+    ? 'Xin lỗi, mình gặp trục trặc khi phân tích tin nhắn. Bạn thử nói lại giúp mình nhé.'
+    : 'Sorry, I ran into an issue while parsing that message. Could you try again?';
+}
+
+export function buildLowConfidenceReply(language: AgentLanguage): string {
+  return language === 'vi'
+    ? 'Mình chưa chắc chắn là hiểu đúng nội dung. Bạn có thể nói rõ hơn hoặc bổ sung thông tin nhé?'
+    : "I'm not fully sure I understood. Could you clarify or add a bit more detail?";
+}
+
+export function buildUndoNotSupportedReply(language: AgentLanguage): string {
+  return language === 'vi'
+    ? 'Mình đang xây dựng tính năng hủy giao dịch. Bạn có thể xóa thủ công trong danh sách giao dịch nhé.'
+    : "I'm still building the undo feature. You can delete the transaction manually in the list for now.";
+}
+
+export function buildUnsupportedIntentReply(language: AgentLanguage): string {
+  return language === 'vi'
+    ? 'Tính năng này chưa được hỗ trợ. Bạn thử yêu cầu khác giúp mình nhé.'
+    : "That capability isn't supported yet. Please try a different request.";
+}
+
+export function buildHandlerErrorReply(language: AgentLanguage): string {
+  return language === 'vi'
+    ? 'Xin lỗi, mình gặp lỗi khi xử lý. Bạn thử lại sau ít phút giúp mình nhé.'
+    : 'Sorry, something went wrong while handling that. Please try again shortly.';
+}
+
+export function buildMissingAmountReply(language: AgentLanguage): string {
+  return language === 'vi'
+    ? 'Mình chưa thấy số tiền. Bạn cho mình biết cụ thể hoặc nhập lại giúp nhé.'
+    : "I didn't catch the amount. Could you tell me the number or rephrase?";
+}
+
+export function buildTransactionSavedReply(
+  language: AgentLanguage,
+  params: { type: TxnType; amount: string; category?: string | null },
+): string {
+  const { type, amount, category } = params;
+  const categoryClause = category
+    ? language === 'vi'
+      ? ` cho ${category}`
+      : ` for ${category}`
+    : '';
+  if (language === 'vi') {
+    const noun = type === TxnType.INCOME ? 'khoản thu' : 'khoản chi';
+    return `Mình đã ghi nhận ${noun} ${amount}${categoryClause}.`;
+  }
+  const base =
+    type === TxnType.INCOME
+      ? `I've recorded income of ${amount}`
+      : `I've recorded an expense of ${amount}`;
+  return `${base}${categoryClause}.`;
+}
+
+export function buildAskBudgetAmountReply(language: AgentLanguage): string {
+  return language === 'vi'
+    ? 'Bạn muốn đặt ngân sách bao nhiêu? Mình cần số tiền cụ thể nhé.'
+    : 'How much budget would you like to set? I need the exact amount.';
+}
+
+export function buildBudgetSetReply(
+  language: AgentLanguage,
+  params: { amountLabel: string; categoryLabel: string; monthLabel: string },
+): string {
+  const { amountLabel, categoryLabel, monthLabel } = params;
+  return language === 'vi'
+    ? `Mình đã cập nhật ngân sách ${amountLabel} cho ${categoryLabel} (${monthLabel}).`
+    : `I've updated the budget to ${amountLabel} for ${categoryLabel} (${monthLabel}).`;
+}
+
+export function buildBudgetNotFoundReply(
+  language: AgentLanguage,
+  params: { target: string; monthLabel: string },
+): string {
+  const { target, monthLabel } = params;
+  return language === 'vi'
+    ? `Mình chưa thấy ${target} trong ${monthLabel}. Bạn có thể đặt ngân sách trước nhé.`
+    : `I couldn't find ${target} in ${monthLabel}. Try setting the budget first.`;
+}
+
+export function buildBudgetStatusReply(
+  language: AgentLanguage,
+  params: {
+    amountLabel: string;
+    limitLabel: string;
+    percentLabel: string;
+    remainingLabel: string;
+    endDateLabel?: string;
+    overBudget: boolean;
+    overspentLabel?: string;
+  },
+): string {
+  const {
+    amountLabel,
+    limitLabel,
+    percentLabel,
+    remainingLabel,
+    endDateLabel,
+    overBudget,
+    overspentLabel,
+  } = params;
+  const trailing = endDateLabel
+    ? language === 'vi'
+      ? ` Ngân sách kết thúc vào ${endDateLabel}.`
+      : ` The budget ends on ${endDateLabel}.`
+    : '';
+
+  if (overBudget && overspentLabel) {
+    const warning = language === 'vi'
+      ? ` Cảnh báo: bạn đã vượt ngân sách ${overspentLabel}.`
+      : ` Warning: you're over budget by ${overspentLabel}.`;
+    return language === 'vi'
+      ? `Bạn đang dùng ${amountLabel} / ${limitLabel} (${percentLabel}).${warning}${trailing}`
+      : `You've spent ${amountLabel} / ${limitLabel} (${percentLabel}).${warning}${trailing}`;
+  }
+
+  const remainingSentence = language === 'vi'
+    ? ` Còn lại ${remainingLabel}.`
+    : ` Remaining ${remainingLabel}.`;
+
+  return language === 'vi'
+    ? `Bạn đang dùng ${amountLabel} / ${limitLabel} (${percentLabel}).${remainingSentence}${trailing}`
+    : `You've spent ${amountLabel} / ${limitLabel} (${percentLabel}).${remainingSentence}${trailing}`;
+}
+
+export function buildBudgetExceededWarning(
+  language: AgentLanguage,
+  status: BudgetStatusResult,
+): string {
+  const target = getBudgetTargetLabel(language, status.budget.category?.name ?? null);
+  const monthLabel = formatMonthYear(status.budget.month, status.budget.year, language);
+  const overspentLabel = formatCurrency(status.overspent, status.budget.currency, language);
+
+  return language === 'vi'
+    ? `Bạn đã vượt ${target} ${overspentLabel} trong ${monthLabel}.`
+    : `You've exceeded ${target} by ${overspentLabel} in ${monthLabel}.`;
+}
+
+export function buildSummaryByCategoryReply(
+  language: AgentLanguage,
+  params: { rangeLabel: string; amountLabel: string; categoryName: string },
+): string {
+  const { rangeLabel, amountLabel, categoryName } = params;
+  return language === 'vi'
+    ? `${rangeLabel} bạn đã chi ${amountLabel} cho ${categoryName}.`
+    : `${rangeLabel}, you spent ${amountLabel} on ${categoryName}.`;
+}
+
+export function buildSummaryTotalsReply(
+  language: AgentLanguage,
+  params: { rangeLabel: string; expenseLabel: string; incomeLabel: string; netLabel: string },
+): string {
+  const { rangeLabel, expenseLabel, incomeLabel, netLabel } = params;
+  return language === 'vi'
+    ? `${rangeLabel} bạn đã chi ${expenseLabel} và thu ${incomeLabel} (chênh lệch ${netLabel}).`
+    : `${rangeLabel}, you spent ${expenseLabel} and earned ${incomeLabel} (net ${netLabel}).`;
+}
+
+export function buildNoTransactionsReply(language: AgentLanguage): string {
+  return language === 'vi'
+    ? 'Chưa có giao dịch nào trong khoảng thời gian đó.'
+    : 'No transactions found for that timeframe.';
+}
+
+export function buildRecentTransactionsHeader(language: AgentLanguage): string {
+  return language === 'vi' ? 'Các giao dịch gần đây:' : 'Recent transactions:';
+}
+
+export function buildRecentTransactionLine(params: {
+  date: string;
+  amount: string;
+  category: string;
+}): string {
+  const { date, amount, category } = params;
+  return `- ${date}: ${amount} (${category})`;
+}
+
+export function buildSmallTalkReply(language: AgentLanguage, name: string): string {
+  return language === 'vi'
+    ? `Chào ${name}! Mình ở đây để giúp bạn quản lý chi tiêu, cứ hỏi nhé.`
+    : `Hi ${name}! I'm here to help you manage your spending, just let me know what you need.`;
+}
+
+export function getCategoryLabel(language: AgentLanguage, categoryName?: string | null): string {
+  if (categoryName) {
+    return categoryName;
+  }
+  return language === 'vi' ? 'tất cả danh mục' : 'all categories';
+}
+
+export function getBudgetTargetLabel(language: AgentLanguage, categoryName?: string | null): string {
+  if (categoryName) {
+    return language === 'vi' ? `ngân sách cho ${categoryName}` : `the ${categoryName} budget`;
+  }
+  return language === 'vi' ? 'ngân sách này' : 'this budget';
+}
+
+export function getOtherCategoryLabel(language: AgentLanguage): string {
+  return language === 'vi' ? 'Khác' : 'Other';
+}

--- a/apps/api/src/agent/utils/classification.util.ts
+++ b/apps/api/src/agent/utils/classification.util.ts
@@ -1,0 +1,5 @@
+import { SYSTEM_PROMPT_TEMPLATE } from '../agent.constants';
+
+export function buildClassificationPrompt(now: Date, timezone: string): string {
+  return SYSTEM_PROMPT_TEMPLATE.replace('{{NOW_ISO}}', now.toISOString()).replace('{{TIMEZONE}}', timezone);
+}

--- a/apps/api/src/agent/utils/payload.util.ts
+++ b/apps/api/src/agent/utils/payload.util.ts
@@ -1,0 +1,119 @@
+import { Logger } from '@nestjs/common';
+import { AgentPayload, AgentPayloadSchema } from '@expense-ai/shared';
+import { DateTime } from 'luxon';
+
+export function logRawCompletion(logger: Logger, raw: string): void {
+  const cleaned = raw.replace(/\s+/g, ' ').trim();
+  const preview = cleaned.length > 1000 ? `${cleaned.slice(0, 1000)}...` : cleaned;
+  logger.debug(`Hyperbolic raw response preview: ${preview}`);
+}
+
+export function parseAgentPayload(logger: Logger, raw: string): AgentPayload {
+  const jsonString = extractJsonString(raw);
+
+  try {
+    const parsed = JSON.parse(jsonString);
+    return AgentPayloadSchema.parse(normalizeAgentPayload(parsed));
+  } catch (error) {
+    const fallback = findJsonObject(raw);
+    if (fallback) {
+      try {
+        const parsedFallback = JSON.parse(fallback);
+        return AgentPayloadSchema.parse(normalizeAgentPayload(parsedFallback));
+      } catch (innerError) {
+        logger.warn('Failed to parse JSON snippet from LLM response', innerError);
+      }
+    }
+    throw error;
+  }
+}
+
+function extractJsonString(raw: string): string {
+  const withoutThinking = raw.replace(/<think>[\s\S]*?<\/think>/g, '').trim();
+  const channelRegex = /<\|channel\|>([a-zA-Z0-9_]+)<\|message\|>([\s\S]*?)(?=(<\|channel\|>[a-zA-Z0-9_]+<\|message\|>)|$)/g;
+
+  let finalContent: string | undefined;
+  let fallbackContent: string | undefined;
+
+  for (const match of withoutThinking.matchAll(channelRegex)) {
+    const channel = match[1];
+    const content = match[2].trim();
+
+    if (channel === 'final') {
+      finalContent = content;
+      break;
+    }
+
+    if (!fallbackContent) {
+      const candidate = findJsonObject(content);
+      if (candidate) {
+        fallbackContent = candidate;
+      }
+    }
+  }
+
+  const target = finalContent ?? fallbackContent ?? withoutThinking;
+  const json = findJsonObject(target);
+
+  if (!json) {
+    throw new Error('No JSON object found in LLM response');
+  }
+
+  return json;
+}
+
+function findJsonObject(text: string): string | undefined {
+  const match = text.match(/\{[\s\S]*\}/);
+  return match ? match[0] : undefined;
+}
+
+function normalizeAgentPayload(payload: unknown): unknown {
+  if (!payload || typeof payload !== 'object') {
+    return payload;
+  }
+
+  const clone: Record<string, unknown> = { ...(payload as Record<string, unknown>) };
+  const occurredAt = clone.occurred_at;
+
+  if (typeof occurredAt === 'string' && occurredAt.trim().length > 0) {
+    const parsed = DateTime.fromISO(occurredAt, { setZone: true });
+    if (parsed.isValid) {
+      clone.occurred_at = parsed.toUTC().toISO();
+    } else {
+      const parsedUTC = DateTime.fromISO(occurredAt);
+      if (parsedUTC.isValid) {
+        clone.occurred_at = parsedUTC.toUTC().toISO();
+      }
+    }
+  }
+
+  const rawBudgetMonth = clone.budget_month;
+  if (typeof rawBudgetMonth === 'string' && rawBudgetMonth.trim().length > 0) {
+    const numericMonth = Number(rawBudgetMonth);
+    clone.budget_month = Number.isFinite(numericMonth) ? numericMonth : rawBudgetMonth;
+  }
+
+  if (typeof clone.budget_month === 'number') {
+    if (clone.budget_month < 1 || clone.budget_month > 12) {
+      delete clone.budget_month;
+    } else {
+      clone.budget_month = Math.trunc(clone.budget_month);
+    }
+  }
+
+  const rawBudgetYear = clone.budget_year;
+  if (typeof rawBudgetYear === 'string' && rawBudgetYear.trim().length > 0) {
+    const numericYear = Number(rawBudgetYear);
+    clone.budget_year = Number.isFinite(numericYear) ? numericYear : rawBudgetYear;
+  }
+
+  if (typeof clone.budget_year === 'number') {
+    if (clone.budget_year < 1900 || clone.budget_year > 3000) {
+      delete clone.budget_year;
+    } else {
+      clone.budget_year = Math.trunc(clone.budget_year);
+    }
+  }
+
+  return clone;
+}

--- a/apps/api/src/agent/utils/rule-based.util.ts
+++ b/apps/api/src/agent/utils/rule-based.util.ts
@@ -1,0 +1,305 @@
+import {
+  AgentPayload,
+  CATEGORY_SYNONYMS,
+  TimePeriodEnum,
+  normalizeText,
+  resolveCategoryName,
+} from '@expense-ai/shared';
+import { DateTime } from 'luxon';
+
+import { AgentLanguage } from '../agent.constants';
+
+const INCOME_KEYWORDS = [
+  'thu nhap',
+  'thuong',
+  'luong',
+  'salary',
+  'income',
+  'bonus',
+  'nhan duoc',
+  'nhan',
+  'duoc cho',
+  'cho tien',
+  'tra luong',
+  'duoc tra',
+];
+
+const EXPENSE_KEYWORDS = [
+  'chi',
+  'mua',
+  'tra',
+  'tieu',
+  'pay',
+  'spent',
+  'spend',
+  'expense',
+  'mua sam',
+  'hoa don',
+];
+
+const QUERY_KEYWORDS = [
+  'tong',
+  'bao nhieu',
+  'thong ke',
+  'liet ke',
+  'danh sach',
+  'bao cao',
+  'tong ket',
+  'so du',
+  'budget',
+  'ngan sach',
+  'bao nhieu tien',
+  'con lai',
+  'status',
+  'bao gom',
+  'la bao nhieu',
+];
+
+const DATE_KEYWORDS: Record<string, TimePeriodEnum> = {
+  'hom nay': TimePeriodEnum.Today,
+  today: TimePeriodEnum.Today,
+  'hom qua': TimePeriodEnum.Yesterday,
+  yesterday: TimePeriodEnum.Yesterday,
+  'tuan nay': TimePeriodEnum.ThisWeek,
+  'this week': TimePeriodEnum.ThisWeek,
+  'thang nay': TimePeriodEnum.ThisMonth,
+  'this month': TimePeriodEnum.ThisMonth,
+  'thang truoc': TimePeriodEnum.LastMonth,
+  'last month': TimePeriodEnum.LastMonth,
+  'nam nay': TimePeriodEnum.ThisYear,
+  'this year': TimePeriodEnum.ThisYear,
+};
+
+const USD_MARKERS = ['usd', 'us$', '$', 'đô', 'do la', 'dollar', 'dol'];
+const VND_MARKERS = ['vnd', 'đ', 'd', 'dong', '₫', 'vnđ'];
+
+export interface RuleBasedOptions {
+  now: Date;
+  timezone: string;
+  language: AgentLanguage;
+}
+
+export function classifyRuleBased(message: string, options: RuleBasedOptions): AgentPayload | null {
+  const normalized = normalizeText(message);
+  if (!normalized) {
+    return null;
+  }
+
+  if (message.includes('?')) {
+    return null;
+  }
+
+  if (QUERY_KEYWORDS.some((keyword) => normalized.includes(keyword))) {
+    return null;
+  }
+
+  const amountInfo = extractAmount(message);
+  if (!amountInfo) {
+    return null;
+  }
+
+  const period = detectPeriod(normalized);
+  const occurredAt = detectExplicitDate(message, normalized, options);
+
+  const intent = detectIntent(normalized, amountInfo.inferredCurrency);
+  const category = detectCategory(message, intent);
+
+  const payload: AgentPayload = {
+    intent,
+    language: options.language,
+    amount: amountInfo.value,
+    currency: amountInfo.currency,
+    category: category ?? undefined,
+    note: message,
+    occurred_at: occurredAt,
+    period,
+    confidence: 0.92,
+  };
+
+  return payload;
+}
+
+interface AmountMatch {
+  value: number;
+  currency: 'VND' | 'USD';
+  inferredCurrency: 'VND' | 'USD';
+}
+
+function extractAmount(message: string): AmountMatch | null {
+  const regex = /(?:(usd|us\$|\$|đô|do la|dollar|dol|vnd|vnđ|₫|đ|dong)\s*)?(\d{1,3}(?:[.,]\d{3})*|\d+(?:[.,]\d+)?)(?:\s*(k|nghin|ngan|ngàn|tr|trieu|triệu|ty|tỷ|m|usd|us\$|\$|vnd|vnđ|₫|đ|dong))?/iu;
+  const match = regex.exec(message);
+  if (!match) {
+    return null;
+  }
+
+  const [, prefix, rawNumber, unitOrCurrency] = match;
+  const unit = unitOrCurrency ? unitOrCurrency.toLowerCase() : undefined;
+  const numeric = normalizeNumber(rawNumber);
+  if (!numeric || numeric <= 0) {
+    return null;
+  }
+
+  let multiplier = 1;
+  if (unit) {
+    if (['k', 'nghin', 'ngan', 'ngàn'].includes(unit)) {
+      multiplier = 1_000;
+    } else if (['tr', 'trieu', 'triệu', 'm'].includes(unit)) {
+      multiplier = 1_000_000;
+    } else if (['ty', 'tỷ'].includes(unit)) {
+      multiplier = 1_000_000_000;
+    }
+  }
+
+  const value = numeric * multiplier;
+  const inferredCurrency = detectCurrencyFromMarkers(prefix, unit);
+  const currency = unit && isCurrencyUnit(unit) ? detectCurrencyFromMarkers(unit) : inferredCurrency;
+
+  return {
+    value,
+    currency,
+    inferredCurrency,
+  };
+}
+
+function normalizeNumber(input: string): number {
+  if (!input) {
+    return NaN;
+  }
+
+  const cleaned = input.replace(/\.(?=\d{3}(?:\D|$))/g, '').replace(/,(?=\d{3}(?:\D|$))/g, '').replace(/,/g, '.');
+  const parsed = Number.parseFloat(cleaned);
+  return Number.isFinite(parsed) ? parsed : NaN;
+}
+
+function detectCurrencyFromMarkers(...markers: (string | undefined)[]): 'VND' | 'USD' {
+  for (const marker of markers) {
+    if (!marker) continue;
+    const lowered = marker.toLowerCase();
+    if (USD_MARKERS.includes(lowered)) {
+      return 'USD';
+    }
+    if (VND_MARKERS.includes(lowered)) {
+      return 'VND';
+    }
+  }
+  return 'VND';
+}
+
+function isCurrencyUnit(value: string): boolean {
+  const lowered = value.toLowerCase();
+  return USD_MARKERS.includes(lowered) || VND_MARKERS.includes(lowered);
+}
+
+function detectIntent(normalized: string, inferredCurrency: 'VND' | 'USD'): AgentPayload['intent'] {
+  if (INCOME_KEYWORDS.some((keyword) => normalized.includes(keyword))) {
+    return 'add_income';
+  }
+
+  if (EXPENSE_KEYWORDS.some((keyword) => normalized.includes(keyword))) {
+    return 'add_expense';
+  }
+
+  if (inferredCurrency === 'USD' || inferredCurrency === 'VND') {
+    return 'add_expense';
+  }
+
+  return 'add_expense';
+}
+
+function detectCategory(message: string, intent: AgentPayload['intent']): string | null {
+  if (intent === 'add_income') {
+    return 'Thu nhập';
+  }
+
+  const normalized = normalizeText(message);
+  if (!normalized) {
+    return null;
+  }
+
+  for (const keyword of Object.keys(CATEGORY_SYNONYMS)) {
+    const normalizedKeyword = normalizeText(keyword);
+    if (normalizedKeyword && normalized.includes(normalizedKeyword)) {
+      return CATEGORY_SYNONYMS[keyword];
+    }
+  }
+
+  return resolveCategoryName(message);
+}
+
+function detectPeriod(normalized: string): TimePeriodEnum | undefined {
+  for (const [keyword, period] of Object.entries(DATE_KEYWORDS)) {
+    if (normalized.includes(keyword)) {
+      return period;
+    }
+  }
+  return undefined;
+}
+
+function detectExplicitDate(
+  message: string,
+  normalized: string,
+  options: RuleBasedOptions,
+): string | undefined {
+  const now = DateTime.fromJSDate(options.now).setZone(options.timezone);
+
+  const isoMatch = message.match(/(\d{4})-(\d{2})-(\d{2})/);
+  if (isoMatch) {
+    const [, year, month, day] = isoMatch;
+    const dt = DateTime.fromObject(
+      { year: Number(year), month: Number(month), day: Number(day) },
+      { zone: options.timezone },
+    );
+    if (dt.isValid) {
+      return dt.toUTC().toISO();
+    }
+  }
+
+  const slashMatch = message.match(/(\d{1,2})[/-](\d{1,2})(?:[/-](\d{2,4}))?/);
+  if (slashMatch) {
+    const [, day, month, year] = slashMatch;
+    const resolvedYear = year ? normalizeYear(Number(year), now.year) : now.year;
+    const dt = DateTime.fromObject(
+      { year: resolvedYear, month: Number(month), day: Number(day) },
+      { zone: options.timezone },
+    );
+    if (dt.isValid) {
+      return dt.toUTC().toISO();
+    }
+  }
+
+  const wordMatch = message.match(/ngay\s+(\d{1,2})(?:\s+thang\s+(\d{1,2}))?(?:\s+nam\s+(\d{2,4}))?/i);
+  if (wordMatch) {
+    const [, day, month, year] = wordMatch;
+    const resolvedMonth = month ? Number(month) : now.month;
+    const resolvedYear = year ? normalizeYear(Number(year), now.year) : now.year;
+    const dt = DateTime.fromObject(
+      { year: resolvedYear, month: resolvedMonth, day: Number(day) },
+      { zone: options.timezone },
+    );
+    if (dt.isValid) {
+      return dt.toUTC().toISO();
+    }
+  }
+
+  if (normalized.includes('hom nay') || normalized.includes('today')) {
+    return now.toUTC().toISO();
+  }
+
+  if (normalized.includes('hom qua') || normalized.includes('yesterday')) {
+    return now.minus({ days: 1 }).toUTC().toISO();
+  }
+
+  return undefined;
+}
+
+function normalizeYear(year: number, currentYear: number): number {
+  if (year < 100) {
+    const century = Math.floor(currentYear / 100) * 100;
+    const candidate = century + year;
+    if (candidate <= currentYear + 1) {
+      return candidate;
+    }
+    return candidate - 100;
+  }
+  return year;
+}


### PR DESCRIPTION
## Summary
- add a rule-based classifier that parses currency, dates, and intent before falling back to the LLM
- implement reusable fast-path utilities for extracting amounts, detecting periods, and mapping categories
- cache category synonym resolution inside the agent service to avoid repeated lookups

## Testing
- npm run lint -- --filter=@expense-ai/api

------
https://chatgpt.com/codex/tasks/task_e_68d3e38be030832a96e863d36e25e2f5