### PR TITLE
feat: add recurring transactions scheduler

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,8 +4,11 @@
   "version": "0.1.0",
   "type": "commonjs",
   "scripts": {
+    "predev": "prisma generate --schema ../../prisma/schema.prisma",
     "dev": "nest start --watch --entryFile apps/api/src/main",
+    "prestart": "prisma generate --schema ../../prisma/schema.prisma",
     "start": "nest start --entryFile apps/api/src/main",
+    "prebuild": "prisma generate --schema ../../prisma/schema.prisma",
     "build": "nest build",
     "lint": "eslint src --ext .ts --max-warnings=0",
     "test": "echo \"TODO: add backend tests\""

--- a/apps/api/src/agent/utils/fast-path.util.ts
+++ b/apps/api/src/agent/utils/fast-path.util.ts
@@ -307,11 +307,11 @@ function detectOccurredAt(
   const explicit = parseExplicitDate(original, timezone, reference);
 
   if (explicit) {
-    return explicit.toUTC().toISO();
+    return toIsoString(explicit);
   }
 
   if (normalized.includes('hom kia')) {
-    return reference.minus({ days: 2 }).toUTC().toISO();
+    return toIsoString(reference.minus({ days: 2 }));
   }
 
   if (
@@ -321,18 +321,18 @@ function detectOccurredAt(
     normalized.includes('sang qua') ||
     normalized.includes('yesterday')
   ) {
-    return reference.minus({ days: 1 }).toUTC().toISO();
+    return toIsoString(reference.minus({ days: 1 }));
   }
 
   if (normalized.includes('tuan truoc') || normalized.includes('last week')) {
-    return reference.minus({ weeks: 1 }).toUTC().toISO();
+    return toIsoString(reference.minus({ weeks: 1 }));
   }
 
   if (normalized.includes('thang truoc') || normalized.includes('last month')) {
-    return reference.minus({ months: 1 }).toUTC().toISO();
+    return toIsoString(reference.minus({ months: 1 }));
   }
 
-  return reference.toUTC().toISO();
+  return toIsoString(reference);
 }
 
 function parseExplicitDate(
@@ -345,7 +345,7 @@ function parseExplicitDate(
     const year = Number(isoMatch[1]);
     const month = Number(isoMatch[2]);
     const day = Number(isoMatch[3]);
-    const dt = DateTime.fromObject({ year, month, day, zone: timezone });
+    const dt = DateTime.fromObject({ year, month, day }, { zone: timezone });
     return dt.isValid ? dt : null;
   }
 
@@ -359,7 +359,7 @@ function parseExplicitDate(
       year += year >= 70 ? 1900 : 2000;
     }
 
-    let candidate = DateTime.fromObject({ day, month, year, zone: timezone });
+    let candidate = DateTime.fromObject({ day, month, year }, { zone: timezone });
     if (!candidate.isValid) {
       return null;
     }
@@ -376,4 +376,9 @@ function parseExplicitDate(
 
 function roundToTwoDecimals(value: number): number {
   return Math.round(value * 100) / 100;
+}
+
+function toIsoString(date: DateTime): string {
+  const iso = date.toUTC().toISO();
+  return iso ?? date.toUTC().toString();
 }

--- a/apps/api/src/agent/utils/fast-path.util.ts
+++ b/apps/api/src/agent/utils/fast-path.util.ts
@@ -1,0 +1,379 @@
+import { AgentPayload, normalizeText, resolveCategoryName } from '@expense-ai/shared';
+import { DateTime } from 'luxon';
+import { AgentLanguage } from '../agent.constants';
+
+interface FastPathOptions {
+  timezone: string;
+  now: Date;
+  language: AgentLanguage;
+}
+
+interface AmountDetectionResult {
+  amount: number;
+  currency: 'VND' | 'USD';
+}
+
+const QUESTION_KEYWORDS = [
+  'bao nhieu',
+  'bao nhieu tien',
+  'tong chi',
+  'tong thu',
+  'tong cong',
+  'bao cao',
+  'thong ke',
+  'ngan sach',
+  'han muc',
+  'report',
+  'status',
+  'liet ke',
+  'danh sach',
+  'list',
+  'summary',
+  'tom tat',
+  'con lai',
+  'bao nhieu con lai',
+  'ngay mai',
+  'tomorrow',
+  'plan',
+  'ke hoach',
+];
+
+const INCOME_KEYWORDS = [
+  'thu nhap',
+  'luong',
+  'salary',
+  'bonus',
+  'thuong',
+  'nhan duoc',
+  'duoc chuyen',
+  'duoc tang',
+  'income',
+  'received',
+  'refund',
+  'hoan tien',
+];
+
+const USD_MESSAGE_KEYWORDS = ['usd', 'dollar', 'dollars', 'buck', 'bucks', 'do la', 'do my'];
+
+const THOUSAND_TOKENS = ['k', 'nghin', 'ngan'];
+const MILLION_TOKENS = ['tr', 'trieu'];
+const VND_TOKENS = ['vnd', 'dong', 'dongs'];
+const USD_TOKENS = ['usd', 'dollar', 'dollars', 'buck', 'bucks', 'us'];
+
+const CATEGORY_CACHE_LIMIT = 500;
+const categoryCache = new Map<string, string | null>();
+
+export function detectFastPathPayload(
+  message: string,
+  options: FastPathOptions,
+): AgentPayload | null {
+  const trimmed = message.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const normalized = normalizeText(trimmed);
+  if (!normalized) {
+    return null;
+  }
+
+  if (shouldSkipFastPath(trimmed, normalized)) {
+    return null;
+  }
+
+  const amountInfo = extractAmountAndCurrency(trimmed, normalized);
+  if (!amountInfo) {
+    return null;
+  }
+
+  const occurredAtIso = detectOccurredAt(trimmed, normalized, options.now, options.timezone);
+  const isIncome = detectIncomeIntent(normalized);
+  const category = detectCategory(normalized, isIncome);
+
+  const payload: AgentPayload = {
+    intent: isIncome ? 'add_income' : 'add_expense',
+    language: options.language,
+    amount: roundToTwoDecimals(amountInfo.amount),
+    currency: amountInfo.currency,
+    occurred_at: occurredAtIso,
+    confidence: 0.95,
+  };
+
+  if (category) {
+    payload.category = category;
+  }
+
+  return payload;
+}
+
+function shouldSkipFastPath(original: string, normalized: string): boolean {
+  if (original.includes('?')) {
+    return true;
+  }
+
+  return QUESTION_KEYWORDS.some((keyword) => normalized.includes(keyword));
+}
+
+function detectIncomeIntent(normalized: string): boolean {
+  return INCOME_KEYWORDS.some((keyword) => normalized.includes(keyword));
+}
+
+function detectCategory(normalized: string, isIncome: boolean): string | null {
+  if (!normalized) {
+    return isIncome ? 'Thu nhập' : null;
+  }
+
+  if (categoryCache.has(normalized)) {
+    return categoryCache.get(normalized) ?? null;
+  }
+
+  const tokens = normalized.split(' ').filter(Boolean);
+  for (let size = Math.min(3, tokens.length); size >= 1; size -= 1) {
+    for (let index = 0; index <= tokens.length - size; index += 1) {
+      const phrase = tokens.slice(index, index + size).join(' ');
+      const resolved = resolveCategoryName(phrase);
+      if (resolved) {
+        setCategoryCache(normalized, resolved);
+        return resolved;
+      }
+    }
+  }
+
+  if (isIncome) {
+    setCategoryCache(normalized, 'Thu nhập');
+    return 'Thu nhập';
+  }
+
+  setCategoryCache(normalized, null);
+  return null;
+}
+
+function setCategoryCache(key: string, value: string | null): void {
+  if (categoryCache.size >= CATEGORY_CACHE_LIMIT) {
+    const oldestKey = categoryCache.keys().next().value;
+    if (oldestKey) {
+      categoryCache.delete(oldestKey);
+    }
+  }
+
+  categoryCache.set(key, value ?? null);
+}
+
+function extractAmountAndCurrency(
+  original: string,
+  normalized: string,
+): AmountDetectionResult | null {
+  const numberRegex = /\d+(?:[.,]\d{3})*(?:[.,]\d+)?/g;
+  const lowerOriginal = original.toLowerCase();
+  let match: RegExpExecArray | null;
+
+  while ((match = numberRegex.exec(original)) !== null) {
+    const rawValue = match[0];
+    const start = match.index;
+    const end = start + rawValue.length;
+
+    const preceding = lowerOriginal.slice(Math.max(0, start - 8), start);
+    const following = lowerOriginal.slice(end, Math.min(lowerOriginal.length, end + 8));
+
+    const suffixMatch = following.match(
+      /^[\s]*(k|nghìn|nghin|ngàn|ngan|tr|triệu|trieu|usd|us[$]|vnd|vnđ|đô|đ|đồng|dong|dollar|bucks|[$])/i,
+    );
+    const prefixMatch = preceding.match(
+      /(usd|us[$]|vnd|vnđ|đô|đ|đồng|dong|dollar|bucks|[$])[\s]*$/i,
+    );
+
+    const suffixToken = suffixMatch?.[1];
+    const prefixToken = prefixMatch?.[1];
+
+    let multiplier = 1;
+    let currency: 'VND' | 'USD' = 'VND';
+    let hasMarker = false;
+
+    const applyToken = (token?: string) => {
+      if (!token) {
+        return;
+      }
+
+      const rawToken = token.trim();
+
+      if (rawToken === '$') {
+        currency = 'USD';
+        hasMarker = true;
+        return;
+      }
+
+      if (rawToken === 'đ' || rawToken === '₫') {
+        currency = 'VND';
+        hasMarker = true;
+        return;
+      }
+
+      if (rawToken === 'đô') {
+        currency = 'USD';
+        hasMarker = true;
+        return;
+      }
+
+      const normalizedToken = normalizeText(token).replace(/\s+/g, '');
+      if (!normalizedToken) {
+        return;
+      }
+
+      if (USD_TOKENS.includes(normalizedToken) || USD_TOKENS.includes(rawToken)) {
+        currency = 'USD';
+        hasMarker = true;
+        return;
+      }
+
+      if (VND_TOKENS.includes(normalizedToken) || VND_TOKENS.includes(rawToken)) {
+        currency = 'VND';
+        hasMarker = true;
+        return;
+      }
+
+      if (THOUSAND_TOKENS.includes(normalizedToken)) {
+        multiplier = 1_000;
+        currency = 'VND';
+        hasMarker = true;
+        return;
+      }
+
+      if (MILLION_TOKENS.includes(normalizedToken)) {
+        multiplier = 1_000_000;
+        currency = 'VND';
+        hasMarker = true;
+      }
+    };
+
+    applyToken(suffixToken);
+    applyToken(prefixToken);
+
+    if (!hasMarker) {
+      const containsVndWord =
+        normalized.includes('vnd') ||
+        normalized.includes('dong') ||
+        lowerOriginal.includes('vnđ') ||
+        lowerOriginal.includes('đồng') ||
+        lowerOriginal.includes('dong') ||
+        original.includes('₫');
+      if (containsVndWord) {
+        hasMarker = true;
+      }
+    }
+
+    if (!hasMarker && USD_MESSAGE_KEYWORDS.some((keyword) => normalized.includes(keyword))) {
+      currency = 'USD';
+      hasMarker = true;
+    }
+
+    const digitsOnly = rawValue.replace(/\D/g, '');
+    if (!hasMarker && digitsOnly.length < 4) {
+      continue;
+    }
+
+    const parsed = parseNumericString(rawValue);
+    if (parsed === null || parsed <= 0) {
+      continue;
+    }
+
+    const amount = parsed * multiplier;
+    if (amount <= 0) {
+      continue;
+    }
+
+    return { amount, currency };
+  }
+
+  return null;
+}
+
+function parseNumericString(raw: string): number | null {
+  const cleaned = raw
+    .replace(/\.(?=\d{3}(\D|$))/g, '')
+    .replace(/,(?=\d{3}(\D|$))/g, '')
+    .replace(/,/g, '.');
+
+  const value = Number(cleaned);
+  return Number.isFinite(value) ? value : null;
+}
+
+function detectOccurredAt(
+  original: string,
+  normalized: string,
+  now: Date,
+  timezone: string,
+): string {
+  const reference = DateTime.fromJSDate(now).setZone(timezone);
+  const explicit = parseExplicitDate(original, timezone, reference);
+
+  if (explicit) {
+    return explicit.toUTC().toISO();
+  }
+
+  if (normalized.includes('hom kia')) {
+    return reference.minus({ days: 2 }).toUTC().toISO();
+  }
+
+  if (
+    normalized.includes('hom qua') ||
+    normalized.includes('toi qua') ||
+    normalized.includes('chieu qua') ||
+    normalized.includes('sang qua') ||
+    normalized.includes('yesterday')
+  ) {
+    return reference.minus({ days: 1 }).toUTC().toISO();
+  }
+
+  if (normalized.includes('tuan truoc') || normalized.includes('last week')) {
+    return reference.minus({ weeks: 1 }).toUTC().toISO();
+  }
+
+  if (normalized.includes('thang truoc') || normalized.includes('last month')) {
+    return reference.minus({ months: 1 }).toUTC().toISO();
+  }
+
+  return reference.toUTC().toISO();
+}
+
+function parseExplicitDate(
+  original: string,
+  timezone: string,
+  reference: DateTime,
+): DateTime | null {
+  const isoMatch = original.match(/(\d{4})[/-](\d{1,2})[/-](\d{1,2})/);
+  if (isoMatch) {
+    const year = Number(isoMatch[1]);
+    const month = Number(isoMatch[2]);
+    const day = Number(isoMatch[3]);
+    const dt = DateTime.fromObject({ year, month, day, zone: timezone });
+    return dt.isValid ? dt : null;
+  }
+
+  const shortMatch = original.match(/(\d{1,2})[/-](\d{1,2})(?:[/-](\d{2,4}))?/);
+  if (shortMatch) {
+    const day = Number(shortMatch[1]);
+    const month = Number(shortMatch[2]);
+    let year = shortMatch[3] ? Number(shortMatch[3]) : reference.year;
+
+    if (year < 100) {
+      year += year >= 70 ? 1900 : 2000;
+    }
+
+    let candidate = DateTime.fromObject({ day, month, year, zone: timezone });
+    if (!candidate.isValid) {
+      return null;
+    }
+
+    if (!shortMatch[3] && candidate > reference.plus({ days: 1 })) {
+      candidate = candidate.minus({ years: 1 });
+    }
+
+    return candidate;
+  }
+
+  return null;
+}
+
+function roundToTwoDecimals(value: number): number {
+  return Math.round(value * 100) / 100;
+}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -7,6 +7,7 @@ import { TransactionsModule } from "./transactions/transactions.module";
 import { BudgetsModule } from "./budgets/budgets.module";
 import { ReportsModule } from "./reports/reports.module";
 import { AgentModule } from "./agent/agent.module";
+import { RecurringTransactionsModule } from "./recurring-transactions/recurring-transactions.module";
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { AgentModule } from "./agent/agent.module";
     BudgetsModule,
     ReportsModule,
     AgentModule,
+    RecurringTransactionsModule,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/common/constants/timezone.constants.ts
+++ b/apps/api/src/common/constants/timezone.constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_TIMEZONE = "Asia/Ho_Chi_Minh";

--- a/apps/api/src/recurring-transactions/dto/create-recurring-transaction.dto.ts
+++ b/apps/api/src/recurring-transactions/dto/create-recurring-transaction.dto.ts
@@ -1,0 +1,76 @@
+import { Type } from "class-transformer";
+import {
+  IsEnum,
+  IsInt,
+  IsISO8601,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsPositive,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  ValidateIf,
+} from "class-validator";
+import { Currency, RecurringFrequency, TxnType } from "@prisma/client";
+
+export class CreateRecurringTransactionDto {
+  @IsEnum(TxnType)
+  type!: TxnType;
+
+  @Type(() => Number)
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @IsPositive()
+  amount!: number;
+
+  @IsOptional()
+  @IsEnum(Currency)
+  currency?: Currency = Currency.VND;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  note?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(191)
+  categoryId?: string;
+
+  @IsEnum(RecurringFrequency)
+  frequency!: RecurringFrequency;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  interval: number = 1;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(31)
+  @ValidateIf((dto) => dto.frequency === RecurringFrequency.MONTHLY)
+  dayOfMonth?: number;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(7)
+  @ValidateIf((dto) => dto.frequency === RecurringFrequency.WEEKLY)
+  weekday?: number;
+
+  @IsISO8601()
+  @IsNotEmpty()
+  startDate!: string;
+
+  @IsOptional()
+  @IsISO8601()
+  endDate?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  timezone?: string;
+}

--- a/apps/api/src/recurring-transactions/recurring-transactions.controller.ts
+++ b/apps/api/src/recurring-transactions/recurring-transactions.controller.ts
@@ -1,0 +1,27 @@
+import { Body, Controller, Delete, Get, Param, Post, UseGuards } from "@nestjs/common";
+import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard";
+import { CurrentUser } from "../common/decorators/current-user.decorator";
+import { PublicUser } from "../users/types/public-user.type";
+import { RecurringTransactionsService } from "./recurring-transactions.service";
+import { CreateRecurringTransactionDto } from "./dto/create-recurring-transaction.dto";
+
+@Controller("recurring-transactions")
+@UseGuards(JwtAuthGuard)
+export class RecurringTransactionsController {
+  constructor(private readonly recurringTransactionsService: RecurringTransactionsService) {}
+
+  @Post()
+  create(@CurrentUser() user: PublicUser, @Body() dto: CreateRecurringTransactionDto) {
+    return this.recurringTransactionsService.create(user.id, dto);
+  }
+
+  @Get()
+  list(@CurrentUser() user: PublicUser) {
+    return this.recurringTransactionsService.list(user.id);
+  }
+
+  @Delete(":id")
+  cancel(@CurrentUser() user: PublicUser, @Param("id") id: string) {
+    return this.recurringTransactionsService.cancel(user.id, id);
+  }
+}

--- a/apps/api/src/recurring-transactions/recurring-transactions.module.ts
+++ b/apps/api/src/recurring-transactions/recurring-transactions.module.ts
@@ -1,0 +1,13 @@
+import { Module } from "@nestjs/common";
+import { ConfigModule } from "@nestjs/config";
+import { RecurringTransactionsController } from "./recurring-transactions.controller";
+import { RecurringTransactionsService } from "./recurring-transactions.service";
+import { TransactionsModule } from "../transactions/transactions.module";
+
+@Module({
+  imports: [ConfigModule, TransactionsModule],
+  controllers: [RecurringTransactionsController],
+  providers: [RecurringTransactionsService],
+  exports: [RecurringTransactionsService],
+})
+export class RecurringTransactionsModule {}

--- a/apps/api/src/recurring-transactions/recurring-transactions.service.ts
+++ b/apps/api/src/recurring-transactions/recurring-transactions.service.ts
@@ -1,0 +1,386 @@
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+  OnModuleDestroy,
+  OnModuleInit,
+} from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { DateTime } from "luxon";
+import { Currency, Prisma, RecurringFrequency } from "@prisma/client";
+import { PrismaService } from "../prisma/prisma.service";
+import { DEFAULT_TIMEZONE } from "../common/constants/timezone.constants";
+import { TransactionsService } from "../transactions/transactions.service";
+import { CreateRecurringTransactionDto } from "./dto/create-recurring-transaction.dto";
+import { CreateTransactionDto } from "../transactions/dto/create-transaction.dto";
+
+const MAX_CATCH_UP_OCCURRENCES = 24;
+
+type RecurringWithCategory = Prisma.RecurringTransactionGetPayload<{
+  include: { category: true };
+}>;
+
+type ScheduleConfig = {
+  frequency: RecurringFrequency;
+  interval: number;
+  dayOfMonth?: number | null;
+  weekday?: number | null;
+};
+
+@Injectable()
+export class RecurringTransactionsService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(RecurringTransactionsService.name);
+  private schedulerHandle: NodeJS.Timeout | null = null;
+  private isProcessing = false;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly configService: ConfigService,
+    private readonly transactionsService: TransactionsService,
+  ) {}
+
+  async onModuleInit() {
+    await this.safeProcessDueOccurrences("startup");
+    this.schedulerHandle = setInterval(() => {
+      void this.safeProcessDueOccurrences("interval");
+    }, 60_000);
+  }
+
+  onModuleDestroy() {
+    if (this.schedulerHandle) {
+      clearInterval(this.schedulerHandle);
+      this.schedulerHandle = null;
+    }
+  }
+
+  async create(userId: string, dto: CreateRecurringTransactionDto) {
+    const timezone = this.resolveTimezone(dto.timezone);
+    const startDate = this.parseDate(dto.startDate, timezone, "startDate");
+    const endDate = dto.endDate ? this.parseDate(dto.endDate, timezone, "endDate") : null;
+
+    if (endDate && endDate < startDate) {
+      throw new BadRequestException("endDate must be greater than or equal to startDate");
+    }
+
+    const interval = dto.interval ?? 1;
+    const schedule: ScheduleConfig = {
+      frequency: dto.frequency,
+      interval,
+      dayOfMonth:
+        dto.frequency === RecurringFrequency.MONTHLY
+          ? dto.dayOfMonth ?? startDate.day
+          : undefined,
+      weekday:
+        dto.frequency === RecurringFrequency.WEEKLY ? dto.weekday ?? startDate.weekday : undefined,
+    };
+
+    if (schedule.frequency === RecurringFrequency.MONTHLY && !schedule.dayOfMonth) {
+      throw new BadRequestException("dayOfMonth is required for monthly recurring transactions");
+    }
+
+    if (schedule.frequency === RecurringFrequency.WEEKLY && !schedule.weekday) {
+      throw new BadRequestException("weekday is required for weekly recurring transactions");
+    }
+
+    const firstOccurrence = this.resolveInitialOccurrence(startDate, schedule);
+
+    if (endDate && firstOccurrence > endDate) {
+      throw new BadRequestException("startDate is after the specified endDate");
+    }
+
+    const record = await this.prisma.recurringTransaction.create({
+      data: {
+        userId,
+        type: dto.type,
+        amount: new Prisma.Decimal(dto.amount),
+        currency: dto.currency ?? Currency.VND,
+        note: dto.note,
+        categoryId: dto.categoryId,
+        frequency: schedule.frequency,
+        interval: schedule.interval,
+        dayOfMonth: schedule.dayOfMonth ?? null,
+        weekday: schedule.weekday ?? null,
+        startDate: firstOccurrence.toUTC().toJSDate(),
+        endDate: endDate ? endDate.toUTC().toJSDate() : null,
+        timezone,
+        nextRunAt: firstOccurrence.toUTC().toJSDate(),
+      },
+      include: { category: true },
+    });
+
+    return this.toResponse(record);
+  }
+
+  async list(userId: string) {
+    const items = await this.prisma.recurringTransaction.findMany({
+      where: { userId },
+      orderBy: { createdAt: "desc" },
+      include: { category: true },
+    });
+
+    return items.map((item) => this.toResponse(item));
+  }
+
+  async cancel(userId: string, id: string) {
+    const existing = await this.prisma.recurringTransaction.findFirst({
+      where: { id, userId },
+    });
+
+    if (!existing) {
+      throw new NotFoundException("Recurring transaction not found");
+    }
+
+    await this.prisma.recurringTransaction.update({
+      where: { id },
+      data: {
+        isActive: false,
+        nextRunAt: null,
+      },
+    });
+
+    return { success: true };
+  }
+
+  async processDueOccurrences(nowInput?: Date | DateTime) {
+    const now = nowInput
+      ? nowInput instanceof DateTime
+        ? nowInput
+        : DateTime.fromJSDate(nowInput)
+      : DateTime.utc();
+
+    const due = await this.prisma.recurringTransaction.findMany({
+      where: {
+        isActive: true,
+        nextRunAt: { lte: now.toJSDate() },
+      },
+      orderBy: { nextRunAt: "asc" },
+      take: 50,
+      include: { category: true },
+    });
+
+    for (const recurrence of due) {
+      try {
+        await this.processSingleRecurrence(recurrence, now);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        this.logger.error(
+          `Failed to process recurring transaction ${recurrence.id}: ${message}`,
+          error instanceof Error ? error.stack : undefined,
+        );
+      }
+    }
+  }
+
+  private async processSingleRecurrence(recurrence: RecurringWithCategory, nowUtc: DateTime) {
+    const timezone = this.resolveTimezone(recurrence.timezone);
+    const endDate = recurrence.endDate
+      ? DateTime.fromJSDate(recurrence.endDate).setZone(timezone)
+      : null;
+    const schedule: ScheduleConfig = {
+      frequency: recurrence.frequency,
+      interval: recurrence.interval,
+      dayOfMonth: recurrence.dayOfMonth ?? undefined,
+      weekday: recurrence.weekday ?? undefined,
+    };
+
+    let nextOccurrence = recurrence.nextRunAt
+      ? DateTime.fromJSDate(recurrence.nextRunAt).setZone(timezone)
+      : this.resolveInitialOccurrence(
+          DateTime.fromJSDate(recurrence.startDate).setZone(timezone),
+          schedule,
+        );
+    const nowZoned = nowUtc.setZone(timezone);
+
+    const occurrences: DateTime[] = [];
+    let iterations = 0;
+
+    while (
+      nextOccurrence <= nowZoned &&
+      (!endDate || nextOccurrence <= endDate) &&
+      iterations < MAX_CATCH_UP_OCCURRENCES
+    ) {
+      occurrences.push(nextOccurrence);
+      nextOccurrence = this.computeNextOccurrence(nextOccurrence, schedule);
+      iterations += 1;
+    }
+
+    const lastOccurrence = occurrences[occurrences.length - 1];
+    const withinEndWindow = !endDate || nextOccurrence <= endDate;
+    const shouldContinue = withinEndWindow && nextOccurrence.isValid;
+    const reachedCatchUpLimit =
+      iterations >= MAX_CATCH_UP_OCCURRENCES && nextOccurrence <= nowZoned && shouldContinue;
+
+    for (const occurrence of occurrences) {
+      await this.createOccurrenceTransaction(recurrence, occurrence);
+    }
+
+    const updateData: Prisma.RecurringTransactionUpdateInput = {};
+
+    if (lastOccurrence) {
+      updateData.lastRunAt = lastOccurrence.toUTC().toJSDate();
+    }
+
+    if (shouldContinue) {
+      updateData.nextRunAt = nextOccurrence.toUTC().toJSDate();
+
+      if (reachedCatchUpLimit) {
+        this.logger.debug(
+          `Recurring transaction ${recurrence.id} still has pending occurrences after reaching processing limit; will continue on next cycle.`,
+        );
+      }
+    } else {
+      updateData.nextRunAt = null;
+      updateData.isActive = false;
+    }
+
+    if (Object.keys(updateData).length > 0) {
+      await this.prisma.recurringTransaction.update({
+        where: { id: recurrence.id },
+        data: updateData,
+      });
+    }
+  }
+
+  private async createOccurrenceTransaction(
+    recurrence: RecurringWithCategory,
+    occurrence: DateTime,
+  ): Promise<void> {
+    try {
+      const dto: CreateTransactionDto = {
+        type: recurrence.type,
+        amount: recurrence.amount.toNumber(),
+        currency: recurrence.currency,
+        note: recurrence.note ?? undefined,
+        categoryId: recurrence.categoryId ?? undefined,
+        occurredAt: occurrence.toUTC().toISO(),
+      };
+
+      await this.transactionsService.create(recurrence.userId, dto, {
+        scheduledFor: occurrence.toUTC().toJSDate(),
+        recurringTransactionId: recurrence.id,
+      });
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+        this.logger.debug(
+          `Skipping duplicate occurrence for recurring transaction ${recurrence.id} at ${occurrence.toISO()}`,
+        );
+        return;
+      }
+
+      throw error;
+    }
+  }
+
+  private resolveInitialOccurrence(startDate: DateTime, schedule: ScheduleConfig): DateTime {
+    switch (schedule.frequency) {
+      case RecurringFrequency.MONTHLY: {
+        const day = schedule.dayOfMonth ?? startDate.day;
+        return this.resolveMonthlyOccurrence(startDate, day);
+      }
+      case RecurringFrequency.WEEKLY: {
+        const weekday = schedule.weekday ?? startDate.weekday;
+        return this.resolveWeeklyOccurrence(startDate, weekday);
+      }
+      default:
+        return startDate;
+    }
+  }
+
+  private computeNextOccurrence(previous: DateTime, schedule: ScheduleConfig): DateTime {
+    switch (schedule.frequency) {
+      case RecurringFrequency.MONTHLY: {
+        const nextBase = previous.plus({ months: schedule.interval });
+        const day = schedule.dayOfMonth ?? nextBase.day;
+        return this.resolveMonthlyOccurrence(nextBase, day);
+      }
+      case RecurringFrequency.WEEKLY:
+        return previous.plus({ weeks: schedule.interval });
+      case RecurringFrequency.DAILY:
+      default:
+        return previous.plus({ days: schedule.interval });
+    }
+  }
+
+  private resolveMonthlyOccurrence(base: DateTime, targetDay: number): DateTime {
+    let candidate = base.set({ day: Math.min(targetDay, base.endOf("month").day) });
+
+    if (candidate < base) {
+      const nextMonth = base.plus({ months: 1 });
+      candidate = nextMonth.set({ day: Math.min(targetDay, nextMonth.endOf("month").day) });
+    }
+
+    return candidate;
+  }
+
+  private resolveWeeklyOccurrence(base: DateTime, targetWeekday: number): DateTime {
+    const normalized = ((targetWeekday - 1) % 7) + 1;
+    const diff = (normalized - base.weekday + 7) % 7;
+    return diff === 0 ? base : base.plus({ days: diff });
+  }
+
+  private parseDate(value: string, timezone: string, field: string): DateTime {
+    const parsed = DateTime.fromISO(value, { zone: timezone });
+    if (!parsed.isValid) {
+      throw new BadRequestException(`${field} is not a valid ISO date`);
+    }
+    return parsed;
+  }
+
+  private resolveTimezone(timezone?: string | null): string {
+    const candidate = timezone ?? this.configService.get<string>("APP_TIMEZONE") ?? DEFAULT_TIMEZONE;
+    const test = DateTime.now().setZone(candidate);
+    if (!test.isValid) {
+      throw new BadRequestException("Invalid timezone");
+    }
+    return candidate;
+  }
+
+  private toResponse(recurrence: RecurringWithCategory) {
+    return {
+      id: recurrence.id,
+      type: recurrence.type,
+      amount: recurrence.amount.toNumber(),
+      currency: recurrence.currency,
+      note: recurrence.note,
+      category: recurrence.category
+        ? { id: recurrence.category.id, name: recurrence.category.name }
+        : null,
+      frequency: recurrence.frequency,
+      interval: recurrence.interval,
+      dayOfMonth: recurrence.dayOfMonth,
+      weekday: recurrence.weekday,
+      startDate: recurrence.startDate.toISOString(),
+      endDate: recurrence.endDate?.toISOString() ?? null,
+      timezone: recurrence.timezone,
+      nextRunAt: recurrence.nextRunAt?.toISOString() ?? null,
+      lastRunAt: recurrence.lastRunAt?.toISOString() ?? null,
+      isActive: recurrence.isActive,
+      createdAt: recurrence.createdAt.toISOString(),
+      updatedAt: recurrence.updatedAt.toISOString(),
+    };
+  }
+
+  private async safeProcessDueOccurrences(trigger: string) {
+    if (this.isProcessing) {
+      this.logger.debug(
+        `Recurring transaction processor is already running; skipping trigger "${trigger}" to avoid overlap.`,
+      );
+      return;
+    }
+
+    this.isProcessing = true;
+
+    try {
+      await this.processDueOccurrences();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(
+        `Processing recurring transactions failed (${trigger}): ${message}`,
+        error instanceof Error ? error.stack : undefined,
+      );
+    } finally {
+      this.isProcessing = false;
+    }
+  }
+}

--- a/prisma/migrations/20250927_add_recurring_transactions/migration.sql
+++ b/prisma/migrations/20250927_add_recurring_transactions/migration.sql
@@ -1,0 +1,51 @@
+-- CreateEnum
+DO $$
+BEGIN
+  CREATE TYPE "public"."RecurringFrequency" AS ENUM ('DAILY', 'WEEKLY', 'MONTHLY');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "public"."RecurringTransaction" (
+  "id" TEXT NOT NULL,
+  "userId" TEXT NOT NULL,
+  "type" "public"."TxnType" NOT NULL,
+  "amount" DECIMAL(18, 2) NOT NULL,
+  "currency" "public"."Currency" NOT NULL DEFAULT 'VND',
+  "note" TEXT,
+  "categoryId" TEXT,
+  "frequency" "public"."RecurringFrequency" NOT NULL,
+  "interval" INTEGER NOT NULL DEFAULT 1,
+  "dayOfMonth" INTEGER,
+  "weekday" INTEGER,
+  "startDate" TIMESTAMP(3) NOT NULL,
+  "endDate" TIMESTAMP(3),
+  "timezone" TEXT NOT NULL,
+  "nextRunAt" TIMESTAMP(3),
+  "lastRunAt" TIMESTAMP(3),
+  "isActive" BOOLEAN NOT NULL DEFAULT TRUE,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "RecurringTransaction_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "RecurringTransaction_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "RecurringTransaction_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "public"."Category"("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "RecurringTransaction_userId_isActive_nextRunAt_idx" ON "public"."RecurringTransaction"("userId", "isActive", "nextRunAt");
+
+-- AlterTable
+ALTER TABLE "public"."Transaction"
+  ADD COLUMN IF NOT EXISTS "recurringTransactionId" TEXT,
+  ADD COLUMN IF NOT EXISTS "scheduledFor" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "Transaction_recurringTransactionId_idx" ON "public"."Transaction"("recurringTransactionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "Transaction_recurringTransactionId_scheduledFor_key" ON "public"."Transaction"("recurringTransactionId", "scheduledFor");
+
+-- AddForeignKey
+ALTER TABLE "public"."Transaction"
+  ADD CONSTRAINT "Transaction_recurringTransactionId_fkey" FOREIGN KEY ("recurringTransactionId") REFERENCES "public"."RecurringTransaction"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,6 +18,12 @@ enum TxnType {
   INCOME
 }
 
+enum RecurringFrequency {
+  DAILY
+  WEEKLY
+  MONTHLY
+}
+
 enum ChatRole {
   USER
   ASSISTANT
@@ -38,6 +44,7 @@ model User {
   transactions  Transaction[]
   budgets       Budget[]
   chatMessages  ChatMessage[]
+  recurringTransactions RecurringTransaction[]
 }
 
 model Category {
@@ -48,6 +55,7 @@ model Category {
   updatedAt DateTime      @updatedAt
   txns      Transaction[]
   budgets   Budget[]
+  recurringTransactions RecurringTransaction[]
 }
 
 model Transaction {
@@ -62,11 +70,16 @@ model Transaction {
   categoryId String?
   category   Category? @relation(fields: [categoryId], references: [id])
   meta       Json?
+  recurringTransactionId String?
+  recurringTransaction   RecurringTransaction? @relation(fields: [recurringTransactionId], references: [id])
+  scheduledFor           DateTime?
   createdAt  DateTime  @default(now())
   updatedAt  DateTime  @updatedAt
 
   @@index([userId, occurredAt])
   @@index([categoryId])
+  @@index([recurringTransactionId])
+  @@unique([recurringTransactionId, scheduledFor])
 }
 
 model Budget {
@@ -95,4 +108,31 @@ model ChatMessage {
   createdAt DateTime           @default(now())
 
   @@index([userId, createdAt])
+}
+
+model RecurringTransaction {
+  id          String    @id @default(cuid())
+  userId      String
+  user        User      @relation(fields: [userId], references: [id])
+  type        TxnType
+  amount      Decimal   @db.Decimal(18, 2)
+  currency    Currency  @default(VND)
+  note        String?
+  categoryId  String?
+  category    Category? @relation(fields: [categoryId], references: [id])
+  frequency   RecurringFrequency
+  interval    Int       @default(1)
+  dayOfMonth  Int?
+  weekday     Int?
+  startDate   DateTime
+  endDate     DateTime?
+  timezone    String
+  nextRunAt   DateTime?
+  lastRunAt   DateTime?
+  isActive    Boolean   @default(true)
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+  transactions Transaction[]
+
+  @@index([userId, isActive, nextRunAt])
 }


### PR DESCRIPTION
## Summary
- introduce Prisma support for recurring transactions including schedule metadata and transaction linkage
- add a recurring transactions module with DTO, controller, and service that schedules timezone-aware executions and exposes create/list/cancel endpoints
- update transaction creation/response handling to carry recurring metadata and share the default timezone constant

## Testing
- npm run lint (apps/api)

------
https://chatgpt.com/codex/tasks/task_e_68d446ca4684832a8434c9cdc27e536d